### PR TITLE
Fix importCsvFromFile() and Add test cases

### DIFF
--- a/Model/Behavior/ImporterBehavior.php
+++ b/Model/Behavior/ImporterBehavior.php
@@ -165,7 +165,7 @@ class ImporterBehavior extends ModelBehavior {
                     $result = false;
                 }
             }
-            if ($result !== true) {
+            if ($result === false) {
                 $invalidLines[$key + 1] = array('message' => __('Yacsv: Invalid Line Format'),
                                                 'validationErrors' => $this->model->validationErrors,
                                                 'line' => $value['line']);

--- a/Test/Case/Model/Behavior/ImporterBehaviorTest.php
+++ b/Test/Case/Model/Behavior/ImporterBehaviorTest.php
@@ -1,0 +1,112 @@
+<?php
+
+
+/**
+ * Dummy class for Behavior Test
+ */
+class Importer extends CakeTestModel {
+
+	public $actsAs = array('Yacsv.Importer');
+	public $importFilterArgs = array(
+		array('name' => 'csv'),
+	);
+	public $importFields = array(
+		'name',
+		'country',
+	);
+
+}
+
+
+/**
+ * TestSuite for Yacsv.importerBehavior
+ */
+class ImporterBehaviorTest extends CakeTestCase {
+
+	public $fixtures = array('plugin.Yacsv.importer');
+	private $csvFile;
+
+	public function setUp() {
+		parent::setUp();
+		$this->Importer = new Importer();
+	}
+
+	public function tearDown() {
+
+	}
+
+	/**
+	 * make CSV file for test
+	 *
+	 */
+	private function _makeDummyCsv($data) {
+		$this->csvFile = TMP . 'importer_' . uniqid() . '.csv';
+		
+		$fp = fopen($this->csvFile, 'w');
+		foreach ($data as $d) {
+			fwrite($fp, $d . "\n");
+		}
+		fclose($fp);
+
+		return $this->csvFile;
+	}
+
+	/**
+	 * @dataProvider csvDataProvider
+	 *
+	 */
+	public function testImportCsvFromFile($data, $expected) {
+
+		$csvFile = $this->_makeDummyCsv($data);
+
+		$options = array(
+			'csvEncoding' => 'UTF-8',
+			'hasHeader' => false,
+			'delimiter' => ',',
+			'enclosure' => '"',
+		);
+
+		$result = $this->Importer->importCsvFromFile($csvFile, $options);
+		$this->assertTrue($result);
+
+		$results = $this->Importer->find('all');
+
+		for($i = 0; $i < count($results); ++$i) {
+			$name = $results[$i]['Importer']['name'];
+			$country = $results[$i]['Importer']['country'];
+
+			$this->assertSame($expected[$i]['name'], $name);
+			$this->assertSame($expected[$i]['country'], $country);
+		}
+	}
+
+	/**
+	 * dataProvider for testImportCsvFromFile
+	 *
+	 */
+	public function csvDataProvider() {
+		$inputs[] = array(
+			'"Oyama","Japan"',
+			'"Suzuki","Antarctica"',
+		);
+		$expected[] = array(
+			array(
+				'name' => 'Oyama',
+				'country' => 'Japan',
+			),
+			array(
+				'name' => 'Suzuki',
+				'country' => 'Antarctica',
+			),
+		);
+
+		$data = array();
+		for($i = 0; $i < count($inputs); ++$i) {
+			$data[] = array($inputs[$i], $expected[$i]);
+		}
+
+		return $data;
+	}
+
+
+}

--- a/Test/Fixture/ImporterFixture.php
+++ b/Test/Fixture/ImporterFixture.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Fixture for Importer Model used by ImporterBehaviorTest
+ *
+ */
+class ImporterFixture extends CakeTestFixture {
+
+	public $fields = array(
+		'id' => array('type' => 'integer', 'key' => 'primary'),
+		'name' => array('type' => 'text'),
+		'country' => array('type' => 'text'),
+		'created' => array('type' => 'timestamp'),
+	);
+
+	public $records = array(
+	);
+
+}


### PR DESCRIPTION
If Model::save() was success, return value is  a  saved data, not a TRUE.

So, this line would fail:
https://github.com/suzuki/Yacsv/blob/master/Model/Behavior/ImporterBehavior.php#L168
